### PR TITLE
Add cached last price function for Polygon API

### DIFF
--- a/phantom_core/polygon.py
+++ b/phantom_core/polygon.py
@@ -12,6 +12,7 @@ from .datasource import DataTimeframe, pg_5m_ohlcv_table
 from .constants import DATA_TIME_ZONE, PERIOD_CNAME
 from .ohlcv import clean_ohlcv
 from .market_dataframe import MarketDataFrame
+from .cache import ttl_cached
 
 
 def _response_empty(resp: Any) -> bool:
@@ -276,3 +277,8 @@ def get_last_price(ticker: str) -> float:
     assert last_trade.price is not None
     last_price = float(last_trade.price)
     return last_price
+
+
+@ttl_cached(20)
+def get_last_price_cached(ticker: str) -> float:
+    return get_last_price(ticker)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "phantom-core"
-version = "0.0.10"
+version = "0.0.11"
 description = "Phantom Core"
 authors = ["Adam Lineberry <ablineberry@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
- Introduced `get_last_price_cached` function with a 20-second TTL cache
- Imported `ttl_cached` decorator from `.cache` module
- Incremented package version to 0.0.11 in pyproject.toml

This change improves performance by caching the last price retrieval from the Polygon API.