### PR TITLE
Add SECOND timeframe and improve OHLCVAggSpec validation

### DIFF
--- a/phantom_core/datasource.py
+++ b/phantom_core/datasource.py
@@ -13,6 +13,7 @@ class DataTimeframe(pd.Timedelta, Enum):
     DAILY = 24 * 60 * 60 * 10**9  # 1 day in nanoseconds
     MIN_5 = 5 * 60 * 10**9        # 5 minutes in nanoseconds
     MIN_1 = 60 * 10**9            # 1 minute in nanoseconds
+    SECOND = 1 * 10**9            # 1 second in nanoseconds
     TIME = 0                      # 0 for time-based features
 
     def to_pandas_offset_str(self) -> str:
@@ -28,6 +29,8 @@ class DataTimeframe(pd.Timedelta, Enum):
             return 'minute', 5
         elif self == DataTimeframe.MIN_1:
             return 'minute', 1
+        elif self == DataTimeframe.SECOND:
+            return 'second', 1
         else:
             raise ValueError("Invalid DataTimeframe")
         

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "phantom-core"
-version = "0.0.12"
+version = "0.0.13"
 description = "Phantom Core"
 authors = ["Adam Lineberry <ablineberry@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
- Added SECOND timeframe to DataTimeframe enum
- Enhanced OHLCVAggSpec validation to support more flexible timeframe configurations
- Updated hash and equality methods for OHLCVAggSpec to include more attributes
- Incremented package version to 0.0.13

These changes provide more granular time resolution and improve data aggregation flexibility.